### PR TITLE
Updated maplib benchmark

### DIFF
--- a/engines/maplib/Dockerfile
+++ b/engines/maplib/Dockerfile
@@ -17,10 +17,10 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 # Copy the wheel file into the container
-COPY maplib-0.15.15-cp39-abi3-manylinux_2_24_x86_64.whl .
+COPY maplib-0.18.6-cp39-abi3-manylinux_2_39_x86_64.whl .
 
 # Install the maplib package
-RUN pip install maplib-0.15.15-cp39-abi3-manylinux_2_24_x86_64.whl
+RUN pip install maplib-0.18.6-cp39-abi3-manylinux_2_39_x86_64.whl
 
 # Copy the rest of the application code into the container
 COPY . .

--- a/engines/maplib/Dockerfile
+++ b/engines/maplib/Dockerfile
@@ -17,10 +17,10 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 # Copy the wheel file into the container
-COPY maplib-0.18.6-cp39-abi3-manylinux_2_39_x86_64.whl .
+COPY maplib-0.18.9-cp39-abi3-manylinux_2_28_x86_64.whl .
 
 # Install the maplib package
-RUN pip install maplib-0.18.6-cp39-abi3-manylinux_2_39_x86_64.whl
+RUN pip maplib-0.18.9-cp39-abi3-manylinux_2_28_x86_64.whl
 
 # Copy the rest of the application code into the container
 COPY . .

--- a/engines/maplib/validate.py
+++ b/engines/maplib/validate.py
@@ -1,6 +1,6 @@
 import os
 import argparse
-from maplib import Mapping
+from maplib import Model
 import time
 import rdflib
 import re
@@ -17,16 +17,16 @@ parser.add_argument('report', metavar='report', help='path to validation report 
 args = parser.parse_args()
 
 def maplib_validate(DATA, SHAPES, REPORT):
-    m = Mapping()
+    m = Model()
     # Start measuring the loading time
     load_tic = time.time()
-    m.read_triples(DATA, base_iri="http://example.net/")
+    m.read(DATA, base_iri="http://example.net/", parallel=True)
     load_tictoc = time.time() - load_tic
     print("Load time: ", load_tictoc)
 
     # Parse shacl shapes to rdflib graph 
     shape_graph = "urn:eu:shacl"
-    m.read_triples(SHAPES, graph=shape_graph, base_iri="http://example.net/")
+    m.read(SHAPES, graph=shape_graph, base_iri="http://example.net/")
 
     # SHACL validation block
     # Measuring the validation time
@@ -36,11 +36,11 @@ def maplib_validate(DATA, SHAPES, REPORT):
     print( "Validation time: ", tictoc)
 
     # Generate report
-    report.graph().write_ntriples(os.path.splitext(REPORT)[0]+".nt")
+    report.graph().write(REPORT, format="ntriples")
 
-    vres_graph = rdflib.Graph()
-    with open(os.path.splitext(REPORT)[0]+".nt", "r", encoding="utf-8") as file:
-        vres_graph.parse(data=file.read(),format="nt")    
-    vres_graph.serialize(format="turtle", destination=REPORT)
+#    vres_graph = rdflib.Graph()
+#    with open(os.path.splitext(REPORT)[0]+".nt", "r", encoding="utf-8") as file:
+#        vres_graph.parse(data=file.read(),format="nt")
+#    vres_graph.serialize(format="turtle", destination=REPORT)
 
 maplib_validate(args.data, args.shapes, args.report)

--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -6,7 +6,7 @@ for engine in maplib jena topbraid rdf4j rdfunit dotnet_rdf pyshacl corese ; do 
     mkdir ./results/$engine/reports
 
     for subset in ./data/ES.ttl ./data/FR.ttl ./data/ERA.ttl; do # #./data/*.ttl; do
-        for shape in ./shapes/tds_shapes.ttl ./shapes/core_shapes.ttl /shapes/era_shapes.ttl ; do # ./shapes/*.ttl; do
+        for shape in ./shapes/tds_shapes.ttl ./shapes/core_shapes.ttl ./shapes/era_shapes.ttl ; do # ./shapes/*.ttl; do
             echo "loading, validation, memory_usage" > ./results/$engine/$(basename "$subset" .ttl)_$(basename "$shape" _shapes.ttl)_results.csv ;
             for ((i=0; i<=5; i++)); do
                 echo \-\> $engine "experiment" $(basename "$subset" .ttl)-$(basename "$shape" _shapes.ttl) run $i;


### PR DESCRIPTION
Bumping this benchmark to the latest version of maplib, which gives a notable increase in performance. This version is available on request. @alexisimo you should already have access, but please contact me if you have any issues.

Additionally, the use of rdflib to create pretty turtle in the maplib benchmark is confounding the measurement of memory usage (this is peak usage), so I have removed this part of the code and replaced it with ntriples serialization. 

I have included my preliminary benchmark results, but have not included these as part of the commit.
There were occasional issues with the benchmark script that caused invalid memory data to be entered into the csvs, and these have been excluded from the computed means. Unsure if this is only an issue on my end. 

[data.csv](https://github.com/user-attachments/files/23543215/data.csv)

Cumulative time, era-ruleset:
<img width="988" height="736" alt="cumulative_time" src="https://github.com/user-attachments/assets/c583b21a-47f8-4c30-b1d8-4be78dd9b79b" />
